### PR TITLE
Add nonstd-span-lite 0.5.0 release

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,5 @@
+project('nonstd-span-lite', 'cpp', version: '0.5.0', license: 'BSL-1.0')
+
+includes = include_directories('include')
+
+nonstd_span_lite_dep = declare_dependency(include_directories: includes)

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = span-lite-0.5.0
+
+source_url = https://codeload.github.com/martinmoene/span-lite/tar.gz/v0.5.0
+source_filename = span-lite-0.5.0.tar.gz
+source_hash = 405ae095bca3c63da28c72a3528369b9ba3996f1992f3ae90fcb01a9d8bdef38


### PR DESCRIPTION
How do I test this before we merge?

When this merges, I'll add all the other `nonstd-*` in a similar fashion.